### PR TITLE
window poetry issue 1 fixed

### DIFF
--- a/python_sbom/private.py
+++ b/python_sbom/private.py
@@ -59,11 +59,12 @@ def get_module_info_from_pypi(module_name, module_cache):
     if parsed is not None:
         module_info = module_cache[module_name]
         release_info = parsed['releases'][module_info['version']]
-        sdist_info = [x for x in release_info
-                      if x['packagetype'] == 'sdist'][0]
+        sdist = [x for x in release_info
+                      if x['packagetype'] == 'sdist']
+        sdist_info = sdist[0] if len(sdist) > 0 else {}
         for field in ['url', 'digests', 'size', 'filename']:
             if field not in module_info:
-                module_info[field] = sdist_info[field]
+                module_info[field] = sdist_info.get(field)
 
 
 def get_module_info(module_name, module_cache={}):


### PR DESCRIPTION
`poetry run python_sbom spdx-poetry-demo
Traceback (most recent call last):
  File "C:\Users\ASUS\AppData\Local\Programs\Python\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\ASUS\AppData\Local\Programs\Python\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\ASUS\AppData\Local\pypoetry\Cache\virtualenvs\spdx-poetry-demo-V2xijPMw-py3.9\Scripts\python_sbom.exe\__main__.py", line 7, in <module>
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\cli.py", line 13, in main
    sys.stdout.write(generate(project_name))
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\api.py", line 14, in generate
    module_info = private.get_module_info(toplevel_package_name)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\private.py", line 93, in get_module_info
    module_cache = get_module_info(dep_name, module_cache)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\private.py", line 93, in get_module_info
    module_cache = get_module_info(dep_name, module_cache)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\private.py", line 85, in get_module_info
    get_module_info_from_pypi(module_name, module_cache)
  File "c:\users\asus\appdata\local\pypoetry\cache\virtualenvs\spdx-poetry-demo-v2xijpmw-py3.9\lib\site-packages\python_sbom\private.py", line 62, in get_module_info_from_pypi
    sdist_info = [x for x in release_info
IndexError: list index out of range`