### PR TITLE
window pipenv issue 2 fixed

### DIFF
--- a/python_sbom/private.py
+++ b/python_sbom/private.py
@@ -98,13 +98,13 @@ def get_module_info(module_name, module_cache={}):
 def spdx_document(toplevel_module_name, module_info):
     d = spdx.document.Document()
     d.namespace = f'http://spdx.org/spdxpackages/' \
-        f'{toplevel_module_name}-{module_info["version"]}'
+        f'{toplevel_module_name}-{module_info.get("version")}'
     d.spdx_id = 'SPDXRef-DOCUMENT'
-    d.name = f'{toplevel_module_name}-{module_info["version"]}'
+    d.name = f'{toplevel_module_name}-{module_info.get("version")}'
     d.version = spdx.version.Version(2, 2)
     d.data_license = spdx.document.License.from_identifier('CC0-1.0')
     d.creation_info.add_creator(spdx.creationinfo.Person(
-        module_info['author']['name'], module_info['author']['email']
+        module_info.get('author', {}).get('name'), module_info.get('author').get('email')
     ))
     d.creation_info.set_created_now()
 


### PR DESCRIPTION
`pipenv run python_sbom D:\LFX\Projects\SPDX\Python\Python\spdx-pipenv-demo
Traceback (most recent call last):
  File "c:\users\asus\appdata\local\programs\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\asus\appdata\local\programs\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\ASUS\.virtualenvs\spdx-pipenv-demo-ZeHL1sXJ\Scripts\python_sbom.exe\__main__.py", line 7, in <module>
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\python_sbom\cli.py", line 13, in main
    sys.stdout.write(generate(project_name))
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\python_sbom\api.py", line 15, in generate
    module_doc = private.spdx_document(toplevel_package_name,
  File "c:\users\asus\.virtualenvs\spdx-pipenv-demo-zehl1sxj\lib\site-packages\python_sbom\private.py", line 101, in spdx_document
    f'{toplevel_module_name}-{module_info["version"]}'
KeyError: 'version'`